### PR TITLE
Fix codecov upload path formatting

### DIFF
--- a/CI/xcode-cloud.yml
+++ b/CI/xcode-cloud.yml
@@ -29,5 +29,4 @@ jobs:
         with:
           flags: unit
           fail_ci_if_error: true
-          files: \
-            ${{ github.workspace }}/build/reports/coverage/*.json
+          files: ${{ github.workspace }}/build/reports/coverage/*.json


### PR DESCRIPTION
## Summary
- fix codecov action `files` value to be on a single line

## Testing
- `swift --version`
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688354c424588330841e24240684651c