### PR TITLE
Use expectation for SceneKit view

### DIFF
--- a/Tests/MemoryCitadelUITests/BasicFlowUITest.swift
+++ b/Tests/MemoryCitadelUITests/BasicFlowUITest.swift
@@ -65,8 +65,10 @@ final class BasicFlowUITest: XCTestCase {
         // Navigate to citadel tab and verify a node appears
         let citadelTab = app.tabBars.buttons.element(boundBy: 1)
         citadelTab.tap()
-        // Wait a moment for scene to load
-        sleep(2)
+        // Wait for the SceneKit view to load
+        let scnView = app.otherElements["citadelSceneView"]
+        let sceneLoaded = expectation(for: NSPredicate(format: "exists == true"), evaluatedWith: scnView, handler: nil)
+        wait(for: [sceneLoaded], timeout: 5)
         // Delete room from MemoryListView (go back) to test removal
         palacesTab.tap()
         firstCell.tap()

--- a/UI/Views/CitadelSceneView.swift
+++ b/UI/Views/CitadelSceneView.swift
@@ -14,6 +14,7 @@ struct CitadelSceneView: UIViewRepresentable {
 
     func makeUIView(context: Context) -> SCNView {
         let scnView = SCNView()
+        scnView.accessibilityIdentifier = "citadelSceneView"
         scnView.backgroundColor = UIColor.systemBackground
         scnView.allowsCameraControl = false
         scnView.antialiasingMode = .multisampling4X


### PR DESCRIPTION
## Summary
- mark Citadel SceneKit view with an accessibility identifier
- wait for the SCNView to load in the UI test instead of sleeping

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688354c4e22883308b747707246bc73c