### PR TITLE
Remove unused property from CitadelSceneVM

### DIFF
--- a/UI/ViewModels/CitadelSceneVM.swift
+++ b/UI/ViewModels/CitadelSceneVM.swift
@@ -16,18 +16,15 @@ public final class CitadelSceneVM: ObservableObject {
 
     private let repository: MemoryRepository
     private let proceduralFactory: ProceduralFactory
-    private let purchaseManager: PurchaseManager
 
     /// References to the persistent camera and light nodes in the scene.
     private var cameraNode: SCNNode?
     private var lightNode: SCNNode?
 
     public init(repository: MemoryRepository = CoreDataMemoryRepository(),
-                proceduralFactory: ProceduralFactory = ProceduralFactory(),
-                purchaseManager: PurchaseManager = PurchaseManager()) {
+                proceduralFactory: ProceduralFactory = ProceduralFactory()) {
         self.repository = repository
         self.proceduralFactory = proceduralFactory
-        self.purchaseManager = purchaseManager
         // Initialise scene with default camera and lighting
         setupScene()
         Task {


### PR DESCRIPTION
## Summary
- remove `purchaseManager` from `CitadelSceneVM`

## Testing
- `xcodebuild -scheme MemoryCitadel -destination 'platform=iOS Simulator,name=iPhone 15' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883590609548330ba82bdaa9cd66a21