### PR TITLE
Use passed parent entities for nav titles

### DIFF
--- a/UI/Views/MemoryListView.swift
+++ b/UI/Views/MemoryListView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /// disappears from the list; a future purge task will remove it
 /// permanently.
 struct MemoryListView: View {
+    private let wing: Wing
     @ObservedObject private var viewModel: MemoryListVM
     @State private var showAddSheet = false
     @State private var title: String = ""
@@ -13,6 +14,7 @@ struct MemoryListView: View {
     @State private var includeDate: Bool = false
 
     init(wing: Wing) {
+        self.wing = wing
         _viewModel = ObservedObject(wrappedValue: MemoryListVM(wing: wing))
     }
 
@@ -48,7 +50,7 @@ struct MemoryListView: View {
                 }
             }
         }
-        .navigationTitle(Text(viewModel.rooms.first?.wing.title ?? "Rooms"))
+        .navigationTitle(Text(wing.title))
         .searchable(text: $viewModel.searchText)
         .onChange(of: viewModel.searchText) { _ in
             Task { await viewModel.refresh() }

--- a/UI/Views/WingListView.swift
+++ b/UI/Views/WingListView.swift
@@ -3,11 +3,13 @@ import SwiftUI
 /// Displays the wings within a specific palace. Users can add new
 /// wings and navigate to the list of rooms in each wing.
 struct WingListView: View {
+    private let palace: MemoryPalace
     @ObservedObject private var viewModel: WingListVM
     @State private var showAddSheet = false
     @State private var newWingTitle: String = ""
 
     init(palace: MemoryPalace) {
+        self.palace = palace
         _viewModel = ObservedObject(wrappedValue: WingListVM(palace: palace))
     }
 
@@ -33,7 +35,7 @@ struct WingListView: View {
         .alert(item: $viewModel.alertError) { error in
             Alert(title: Text(error.errorDescription ?? "Error"))
         }
-        .navigationBarTitle(Text(viewModel.wings.first?.palace.name ?? "Wings"), displayMode: .inline)
+        .navigationBarTitle(Text(palace.name), displayMode: .inline)
         .navigationBarItems(trailing: Button(action: {
             showAddSheet = true
         }) {


### PR DESCRIPTION
## Summary
- keep the associated palace/wing on `WingListView` and `MemoryListView`
- show those stored titles in the navigation bars

## Testing
- `xcodebuild -scheme MemoryCitadel -destination 'platform=iOS Simulator,name=iPhone 15' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883590662d08330a631f0f9dfa8bb21