### PR TITLE
Add persistent dark mode setting

### DIFF
--- a/MemoryCitadelApp.swift
+++ b/MemoryCitadelApp.swift
@@ -17,9 +17,9 @@ struct MemoryCitadelApp: App {
     /// and handling StoreKit subscription events.
     @StateObject private var purchaseManager = PurchaseManager()
 
-    /// The global app theme. In a real application this might be
-    /// persisted in user defaults and toggled by the settings view.
-    @State private var isDarkMode: Bool = false
+    /// The global app theme. This is persisted using `AppStorage` so the
+    /// user's choice is stored across launches.
+    @AppStorage("isDarkMode") private var isDarkMode: Bool = false
 
     var body: some Scene {
         WindowGroup {

--- a/Resources/Localizable.strings
+++ b/Resources/Localizable.strings
@@ -24,6 +24,7 @@
 "Free" = "Free";
 "Unlock Premium" = "Unlock Premium";
 "Appearance" = "Appearance";
+"Dark Mode" = "Dark Mode";
 "A data error occurred." = "A data error occurred.";
 "A sync error occurred." = "A sync error occurred.";
 "A purchase error occurred." = "A purchase error occurred.";

--- a/Resources/Localizable.strings (de)
+++ b/Resources/Localizable.strings (de)
@@ -24,6 +24,7 @@
 "Free" = "Kostenlos";
 "Unlock Premium" = "Premium freischalten";
 "Appearance" = "Aussehen";
+"Dark Mode" = "Dunkelmodus";
 "A data error occurred." = "Es ist ein Datenfehler aufgetreten.";
 "A sync error occurred." = "Es ist ein Synchronisationsfehler aufgetreten.";
 "A purchase error occurred." = "Beim Kauf ist ein Fehler aufgetreten.";

--- a/UI/Views/SettingsView.swift
+++ b/UI/Views/SettingsView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 struct SettingsView: View {
     @EnvironmentObject private var purchaseManager: PurchaseManager
     @State private var isPurchasing: Bool = false
+    @AppStorage("isDarkMode") private var isDarkMode: Bool = false
 
     var body: some View {
         Form {
@@ -43,8 +44,9 @@ struct SettingsView: View {
             }
 
             Section(header: Text("Appearance")) {
-                Text("Theme selection is not yet implemented.")
-                    .foregroundColor(.secondary)
+                Toggle(isOn: $isDarkMode) {
+                    Text("Dark Mode")
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- persist theme choice using `AppStorage`
- expose theme toggle in SettingsView
- localize new "Dark Mode" label

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688360a491288330972bbc26ca040422