### PR TITLE
Inject context into CitadelSceneVM

### DIFF
--- a/Tests/MemoryCitadelTests/CitadelSceneVMTests.swift
+++ b/Tests/MemoryCitadelTests/CitadelSceneVMTests.swift
@@ -15,7 +15,8 @@ final class CitadelSceneVMTests: XCTestCase {
         purchaseManager = PurchaseManager()
         repository = CoreDataMemoryRepository(persistenceController: persistenceController,
                                               purchaseManager: purchaseManager)
-        viewModel = CitadelSceneVM(repository: repository)
+        viewModel = CitadelSceneVM(repository: repository,
+                                   context: persistenceController.container.viewContext)
     }
 
     override func tearDown() {

--- a/UI/ViewModels/CitadelSceneVM.swift
+++ b/UI/ViewModels/CitadelSceneVM.swift
@@ -17,6 +17,7 @@ public final class CitadelSceneVM: ObservableObject {
 
     private let repository: MemoryRepository
     private let proceduralFactory: ProceduralFactory
+    private let context: NSManagedObjectContext
 
     /// Holds Combine subscriptions for context change notifications.
     private var cancellables: Set<AnyCancellable> = []
@@ -26,15 +27,17 @@ public final class CitadelSceneVM: ObservableObject {
     private var lightNode: SCNNode?
 
     public init(repository: MemoryRepository = CoreDataMemoryRepository(),
-                proceduralFactory: ProceduralFactory = ProceduralFactory()) {
+                proceduralFactory: ProceduralFactory = ProceduralFactory(),
+                context: NSManagedObjectContext = PersistenceController.shared.container.viewContext) {
         self.repository = repository
         self.proceduralFactory = proceduralFactory
+        self.context = context
         // Initialise scene with default camera and lighting
         setupScene()
         // Observe context changes to update the scene automatically
         NotificationCenter.default.publisher(
             for: .NSManagedObjectContextObjectsDidChange,
-            object: PersistenceController.shared.container.viewContext
+            object: context
         )
         .sink { [weak self] notification in
             guard let self else { return }

--- a/UI/Views/RootView.swift
+++ b/UI/Views/RootView.swift
@@ -9,6 +9,7 @@ struct RootView: View {
     /// The purchase manager used to determine access to premium
     /// features such as additional palaces.
     @EnvironmentObject private var purchaseManager: PurchaseManager
+    @Environment(\.managedObjectContext) private var context
 
     var body: some View {
         TabView {
@@ -22,7 +23,7 @@ struct RootView: View {
             }
 
             NavigationView {
-                CitadelSceneView()
+                CitadelSceneView(viewModel: CitadelSceneVM(context: context))
                     .navigationTitle(Text("Citadel"))
             }
             .tabItem {


### PR DESCRIPTION
## Summary
- pass an `NSManagedObjectContext` into `CitadelSceneVM` and observe it for Core Data changes
- wire `CitadelSceneVM` up to the environment context in `RootView`
- update unit tests for the new initializer

## Testing
- `xcodebuild -scheme MemoryCitadel -destination 'platform=iOS Simulator,name=iPhone 15' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688369f2060883309a62be1e17719fa6