### PR TITLE
Add PurchaseManager StoreKit tests

### DIFF
--- a/Tests/MemoryCitadelTests/PurchaseManagerTests.swift
+++ b/Tests/MemoryCitadelTests/PurchaseManagerTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+import StoreKit
+import StoreKitTest
+@testable import MemoryCitadel
+
+/// Tests for the PurchaseManager using a mocked StoreKit environment.
+/// A StoreKitTest session simulates transactions so methods can be
+/// exercised without real network calls.
+final class PurchaseManagerTests: XCTestCase {
+    var session: SKTestSession!
+
+    override func setUpWithError() throws {
+        session = try SKTestSession(configurationFileNamed: "TestConfiguration")
+        session.resetToDefaultState()
+        session.disableDialogs = true
+        session.clearTransactions()
+    }
+
+    override func tearDownWithError() throws {
+        session = nil
+    }
+
+    /// Buying the premium product should grant the premium entitlement
+    /// once `updateEntitlement()` processes the transaction.
+    func testUpdateEntitlementPremium() async throws {
+        try session.buyProduct(identifier: "citadel.premium")
+        let manager = PurchaseManager()
+        await manager.updateEntitlement()
+        XCTAssertEqual(manager.entitlement, .premium)
+    }
+
+    /// The purchase flow should set the entitlement to premium on
+    /// success.
+    func testPurchasePremiumUpdatesEntitlement() async throws {
+        let manager = PurchaseManager()
+        try await manager.purchasePremium()
+        XCTAssertEqual(manager.entitlement, .premium)
+    }
+}

--- a/Tests/MemoryCitadelTests/TestConfiguration.storekit
+++ b/Tests/MemoryCitadelTests/TestConfiguration.storekit
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>identifier</key>
+  <string>TestConfiguration</string>
+  <key>storeKitConfigurationVersion</key>
+  <string>1.0</string>
+  <key>data</key>
+  <dict>
+    <key>products</key>
+    <array>
+      <dict>
+        <key>referenceName</key>
+        <string>Premium</string>
+        <key>productIdentifier</key>
+        <string>citadel.premium</string>
+        <key>displayName</key>
+        <string>Premium</string>
+        <key>familyShareable</key>
+        <false/>
+        <key>productType</key>
+        <string>non-consumable</string>
+        <key>price</key>
+        <real>0.00</real>
+        <key>localizations</key>
+        <dict>
+          <key>en_US</key>
+          <dict>
+            <key>name</key>
+            <string>Premium</string>
+            <key>description</key>
+            <string>Premium unlock</string>
+          </dict>
+        </dict>
+      </dict>
+    </array>
+  </dict>
+  <key>environment</key>
+  <string>Xcode</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- add `PurchaseManagerTests` using `SKTestSession`
- provide `TestConfiguration.storekit` for mocked StoreKit products

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -scheme MemoryCitadel -destination 'platform=iOS Simulator,name=iPhone 15'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688369f3ca78833092e349bcc469f60f