### PR TITLE
Implement purge, tap detection and attachments

### DIFF
--- a/Domain/Entities/MemoryRoom.swift
+++ b/Domain/Entities/MemoryRoom.swift
@@ -1,6 +1,19 @@
 import CoreData
 import Foundation
 
+/// Represents a single attachment linked to a memory room.
+public struct RoomAttachment: Codable, Identifiable, Hashable {
+    public let id: UUID
+    public let fileURLData: Data // Storing bookmark data for the URL
+    public var fileName: String
+
+    public init(fileURL: URL) throws {
+        self.id = UUID()
+        self.fileName = fileURL.lastPathComponent
+        self.fileURLData = try fileURL.bookmarkData(options: .minimalBookmark, includingResourceValuesForKeys: nil, relativeTo: nil)
+    }
+}
+
 /// Represents a single memory cue within a wing. Each room can
 /// optionally be scheduled by date and hold arbitrary attachments
 /// encoded as a JSON array of file URLs. Rooms can be archived

--- a/Extensions/SceneKit+Helpers.swift
+++ b/Extensions/SceneKit+Helpers.swift
@@ -27,4 +27,12 @@ public extension SCNNode {
         let action = SCNAction.fadeIn(duration: duration)
         runAction(action)
     }
+
+    /// Traverses up the scene graph to find the root node of a building.
+    func findBuildingRoot() -> SCNNode? {
+        if let name = name, name.hasPrefix("Building_") {
+            return self
+        }
+        return parent?.findBuildingRoot()
+    }
 }

--- a/MemoryCitadelApp.swift
+++ b/MemoryCitadelApp.swift
@@ -28,6 +28,9 @@ struct MemoryCitadelApp: App {
     /// and handling StoreKit subscription events.
     @StateObject private var purchaseManager = PurchaseManager()
 
+    /// Repository used for housekeeping tasks such as purging rooms.
+    private let repository = CoreDataMemoryRepository()
+
     /// The global app theme. This is persisted using `AppStorage` so the
     /// user's choice is stored across launches.
     @AppStorage("isDarkMode") private var isDarkMode: Bool = false
@@ -38,6 +41,11 @@ struct MemoryCitadelApp: App {
                 .environment(\.managedObjectContext, persistenceController.container.viewContext)
                 .environmentObject(purchaseManager)
                 .preferredColorScheme(isDarkMode ? .dark : .light)
+                .task {
+                    // Wait 5 seconds after launch to run the purge
+                    try? await Task.sleep(nanoseconds: 5_000_000_000)
+                    try? await repository.purgeArchivedRooms()
+                }
         }
     }
 }

--- a/UI/ViewModels/MemoryListVM.swift
+++ b/UI/ViewModels/MemoryListVM.swift
@@ -32,9 +32,9 @@ public final class MemoryListVM: ObservableObject {
         }
     }
 
-    public func addRoom(title: String, detail: String?, date: Date?) async {
+    public func addRoom(title: String, detail: String?, date: Date?, attachments: Data?) async {
         do {
-            _ = try await repository.createRoom(in: wing, title: title, detail: detail, date: date, attachments: nil)
+            _ = try await repository.createRoom(in: wing, title: title, detail: detail, date: date, attachments: attachments)
             await refresh()
         } catch let error as CitadelError {
             alertError = error

--- a/UI/Views/DocumentPicker.swift
+++ b/UI/Views/DocumentPicker.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+import UIKit
+
+struct DocumentPicker: UIViewControllerRepresentable {
+    var onPick: (URL) -> Void
+
+    func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
+        let picker = UIDocumentPickerViewController(forOpeningContentTypes: [.item], asCopy: true)
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIDocumentPickerViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator: NSObject, UIDocumentPickerDelegate {
+        var parent: DocumentPicker
+
+        init(_ parent: DocumentPicker) {
+            self.parent = parent
+        }
+
+        func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+            guard let url = urls.first else { return }
+            let success = url.startAccessingSecurityScopedResource()
+            defer { url.stopAccessingSecurityScopedResource() }
+
+            if success {
+                parent.onPick(url)
+            }
+        }
+    }
+}

--- a/UI/Views/MemoryListView.swift
+++ b/UI/Views/MemoryListView.swift
@@ -13,6 +13,8 @@ struct MemoryListView: View {
     @State private var date: Date = Date()
     @State private var includeDate: Bool = false
     @State private var newRoomTitle: String = ""
+    @State private var attachments: [RoomAttachment] = []
+    @State private var showDocumentPicker = false
 
     init(wing: Wing) {
         self.wing = wing
@@ -58,7 +60,7 @@ struct MemoryListView: View {
                         let trimmedTitle = newRoomTitle.trimmingCharacters(in: .whitespacesAndNewlines)
                         guard !trimmedTitle.isEmpty else { return }
                         Task {
-                            await viewModel.addRoom(title: trimmedTitle, detail: nil, date: nil)
+                            await viewModel.addRoom(title: trimmedTitle, detail: nil, date: nil, attachments: nil)
                             newRoomTitle = ""
                         }
                     }) {
@@ -100,6 +102,16 @@ struct MemoryListView: View {
                     Section(header: Text("Detail")) {
                         TextField("Detail", text: $detail)
                     }
+                    Section(header: Text("Attachments")) {
+                        ForEach(attachments, id: \.id) { attachment in
+                            Text(attachment.fileName)
+                        }
+                        .onDelete(perform: deleteAttachment)
+
+                        Button("Add Attachment...") {
+                            showDocumentPicker = true
+                        }
+                    }
                     Section {
                         Toggle(isOn: $includeDate) {
                             Text("Schedule Date")
@@ -124,8 +136,9 @@ struct MemoryListView: View {
                             let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
                             guard !trimmedTitle.isEmpty else { return }
                             let optionalDate = includeDate ? date : nil
+                            let attachmentsData = try? JSONEncoder().encode(attachments)
                             Task {
-                                await viewModel.addRoom(title: trimmedTitle, detail: detail.isEmpty ? nil : detail, date: optionalDate)
+                                await viewModel.addRoom(title: trimmedTitle, detail: detail.isEmpty ? nil : detail, date: optionalDate, attachments: attachmentsData)
                                 clearInputs()
                                 showAddSheet = false
                             }
@@ -135,12 +148,27 @@ struct MemoryListView: View {
                 }
             }
         }
+        .sheet(isPresented: $showDocumentPicker) {
+            DocumentPicker { url in
+                do {
+                    let attachment = try RoomAttachment(fileURL: url)
+                    attachments.append(attachment)
+                } catch {
+                    print("Failed to create bookmark for URL: \(error)")
+                }
+            }
+        }
     }
 
     private func clearInputs() {
         title = ""
         detail = ""
         includeDate = false
+        attachments.removeAll()
+    }
+
+    private func deleteAttachment(at offsets: IndexSet) {
+        attachments.remove(atOffsets: offsets)
     }
 }
 

--- a/UI/Views/RootView.swift
+++ b/UI/Views/RootView.swift
@@ -23,7 +23,10 @@ struct RootView: View {
             }
 
             NavigationView {
-                CitadelSceneView(viewModel: CitadelSceneVM(context: context))
+                CitadelSceneView(viewModel: CitadelSceneVM(context: context)) { roomID in
+                    print("Tapped on room with ID: \(roomID)")
+                    // Navigation logic will be added here in the future
+                }
                     .navigationTitle(Text("Citadel"))
             }
             .tabItem {

--- a/UI/Views/SettingsView.swift
+++ b/UI/Views/SettingsView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 struct SettingsView: View {
     @EnvironmentObject private var purchaseManager: PurchaseManager
     @State private var isPurchasing: Bool = false
+    @State private var alertError: CitadelError?
     @AppStorage("isDarkMode") private var isDarkMode: Bool = false
 
     var body: some View {
@@ -26,10 +27,11 @@ struct SettingsView: View {
                             do {
                                 try await purchaseManager.purchasePremium()
                             } catch let error as CitadelError {
-                                // The view itself does not present alerts; instead the root view may
-                                print("Purchase error: \(error)")
+                                // Assign the error to trigger the alert
+                                self.alertError = error
                             } catch {
-                                print("Unknown purchase error: \(error)")
+                                // Wrap the unknown error and assign it
+                                self.alertError = .purchase(error)
                             }
                         }
                     }) {
@@ -48,6 +50,13 @@ struct SettingsView: View {
                     Text("Dark Mode")
                 }
             }
+        }
+        .alert(item: $alertError) { error in
+            Alert(
+                title: Text("Purchase Failed"),
+                message: Text(error.errorDescription ?? "An unknown error occurred."),
+                dismissButton: .default(Text("OK"))
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- purge archived rooms after launch
- detect building taps in `CitadelSceneView`
- expose user facing alert for failed purchases
- allow adding file attachments when creating rooms

## Testing
- `xcodebuild test -scheme MemoryCitadel -destination 'platform=iOS Simulator,name=iPhone 15'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888840c29b083308173f272e8cf7671