### PR TITLE
Add detail navigation and biome enhancements

### DIFF
--- a/Domain/Services/MemoryRepository.swift
+++ b/Domain/Services/MemoryRepository.swift
@@ -18,6 +18,7 @@ public protocol MemoryRepository {
     func archiveRoom(_ room: MemoryRoom) async throws
     func deleteRoom(_ room: MemoryRoom) async throws
     func purgeArchivedRooms() async throws
+    func fetchRoom(id: UUID) async throws -> MemoryRoom?
 }
 
 
@@ -165,6 +166,18 @@ public final class CoreDataMemoryRepository: MemoryRepository {
         do {
             try context.execute(deleteRequest)
             try persistenceController.saveContext()
+        } catch {
+            throw CitadelError.coreData(error)
+        }
+    }
+
+    public func fetchRoom(id: UUID) async throws -> MemoryRoom? {
+        let request: NSFetchRequest<MemoryRoom> = MemoryRoom.fetchRequest()
+        request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+        request.fetchLimit = 1
+        do {
+            let result = try persistenceController.container.viewContext.fetch(request)
+            return result.first
         } catch {
             throw CitadelError.coreData(error)
         }

--- a/Domain/Services/ProceduralFactory.swift
+++ b/Domain/Services/ProceduralFactory.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SceneKit
 import GameplayKit
+import UIKit
 
 /// Generates deterministic geometry for a memory room. By seeding the
 /// random number generator with a value derived from the room's UUID the
@@ -14,7 +15,7 @@ public struct ProceduralFactory {
     /// debugging.
     /// - Parameter room: the memory room to base the geometry on
     /// - Returns: a root `SCNNode` representing the building
-    public func makeBuildingNode(for room: MemoryRoom) -> SCNNode {
+    public func makeBuildingNode(for room: MemoryRoom, wingIndex: Int) -> SCNNode {
         // Seed RNG with a deterministic value derived from the room UUID
         let seed = withUnsafeBytes(of: room.id.uuid) { ptr in
             ptr.load(as: UInt64.self).bigEndian
@@ -32,7 +33,7 @@ public struct ProceduralFactory {
         // Foundation
         let foundationHeight: CGFloat = 0.5
         let foundationGeometry = SCNBox(width: width, height: foundationHeight, length: length, chamferRadius: 0.1)
-        foundationGeometry.firstMaterial = triToneMaterial(seed: seed, index: 0)
+        foundationGeometry.firstMaterial = triToneMaterial(seed: seed, index: 0, wingIndex: wingIndex)
         let foundationNode = SCNNode(geometry: foundationGeometry)
         foundationNode.position = SCNVector3(0, foundationHeight / 2.0, 0)
         foundationNode.name = "Foundation"
@@ -41,7 +42,7 @@ public struct ProceduralFactory {
         // Walls
         let wallHeight: CGFloat = CGFloat(random.nextInt(upperBound: 3) + 1)
         let wallGeometry = SCNBox(width: width * 0.9, height: wallHeight, length: length * 0.9, chamferRadius: 0.05)
-        wallGeometry.firstMaterial = triToneMaterial(seed: seed, index: 1)
+        wallGeometry.firstMaterial = triToneMaterial(seed: seed, index: 1, wingIndex: wingIndex)
         let wallNode = SCNNode(geometry: wallGeometry)
         wallNode.position = SCNVector3(0, foundationHeight + wallHeight / 2.0, 0)
         wallNode.name = "Walls"
@@ -58,7 +59,7 @@ public struct ProceduralFactory {
         } else {
             roofGeometry = SCNCone(topRadius: 0.0, bottomRadius: max(width, length) * 0.5, height: roofHeight)
         }
-        roofGeometry.firstMaterial = triToneMaterial(seed: seed, index: 2)
+        roofGeometry.firstMaterial = triToneMaterial(seed: seed, index: 2, wingIndex: wingIndex)
         let roofNode = SCNNode(geometry: roofGeometry)
         roofNode.position = SCNVector3(0, foundationHeight + wallHeight + roofHeight / 2.0, 0)
         roofNode.name = "Roof"
@@ -69,7 +70,7 @@ public struct ProceduralFactory {
         if chance > 0.8 {
             let poleHeight: CGFloat = 1.2
             let poleGeometry = SCNCylinder(radius: 0.05, height: poleHeight)
-            poleGeometry.firstMaterial = triToneMaterial(seed: seed, index: 3)
+            poleGeometry.firstMaterial = triToneMaterial(seed: seed, index: 3, wingIndex: wingIndex)
             let poleNode = SCNNode(geometry: poleGeometry)
             poleNode.position = SCNVector3(0, foundationHeight + wallHeight + roofHeight + poleHeight / 2.0, 0)
             poleNode.name = "TowerPole"
@@ -79,12 +80,35 @@ public struct ProceduralFactory {
             let flagWidth: CGFloat = 1.0
             let flagHeight: CGFloat = 0.4
             let flagGeometry = SCNPlane(width: flagWidth, height: flagHeight)
-            flagGeometry.firstMaterial = triToneMaterial(seed: seed, index: 4)
+            flagGeometry.firstMaterial = triToneMaterial(seed: seed, index: 4, wingIndex: wingIndex)
             let flagNode = SCNNode(geometry: flagGeometry)
             flagNode.position = SCNVector3(flagWidth / 2.0, 0.0, 0)
             flagNode.eulerAngles.y = -.pi / 2
             flagNode.name = "TowerFlag"
             poleNode.addChildNode(flagNode)
+        }
+
+        // Decorative trees around the building
+        let treeCount = random.nextInt(upperBound: 3) + 1
+        for i in 0..<treeCount {
+            let trunk = SCNCylinder(radius: 0.05, height: 0.6)
+            trunk.firstMaterial?.diffuse.contents = UIColor.brown
+            let trunkNode = SCNNode(geometry: trunk)
+            trunkNode.position = SCNVector3(0, 0.3, 0)
+
+            let cone = SCNCone(topRadius: 0, bottomRadius: 0.3, height: 0.6)
+            cone.firstMaterial?.diffuse.contents = UIColor.green
+            let coneNode = SCNNode(geometry: cone)
+            coneNode.position = SCNVector3(0, 0.6, 0)
+
+            let treeRoot = SCNNode()
+            treeRoot.addChildNode(trunkNode)
+            treeRoot.addChildNode(coneNode)
+
+            let angle = Float(i) / Float(treeCount) * Float.pi * 2.0
+            let radius = Float(2.5 + random.nextUniform())
+            treeRoot.position = SCNVector3(cos(angle) * radius, 0, sin(angle) * radius)
+            rootNode.addChildNode(treeRoot)
         }
         return rootNode
     }
@@ -93,10 +117,13 @@ public struct ProceduralFactory {
     /// index. This mimics a stylised metal shader with ambient
     /// occlusion baked into the vertex colours. For production you
     /// would implement a custom shader; here we use plain colours.
-    private func triToneMaterial(seed: UInt64, index: Int) -> SCNMaterial {
+    private func triToneMaterial(seed: UInt64, index: Int, wingIndex: Int) -> SCNMaterial {
         let material = SCNMaterial()
-        // Use the index to derive a hue offset for variety
-        let hue = CGFloat((Int(seed) + index * 57) % 360) / 360.0
+        // Base hue is influenced by the wing index to create biomes
+        let baseHue: CGFloat = wingIndex % 2 == 0 ? 0.6 : 0.05
+        // Add a deterministic offset for variety
+        let offset = CGFloat((Int(seed) + index * 57) % 100) / 1000.0
+        let hue = baseHue + offset
         let baseColor = UIColor(hue: hue, saturation: 0.5, brightness: 0.7, alpha: 1.0)
         material.diffuse.contents = baseColor
         material.specular.contents = UIColor.white.withAlphaComponent(0.3)

--- a/Tests/MemoryCitadelTests/ProceduralFactoryTests.swift
+++ b/Tests/MemoryCitadelTests/ProceduralFactoryTests.swift
@@ -15,8 +15,8 @@ final class ProceduralFactoryTests: XCTestCase {
         room.createdAt = Date()
         room.updatedAt = Date()
         let factory = ProceduralFactory()
-        let nodeA = factory.makeBuildingNode(for: room)
-        let nodeB = factory.makeBuildingNode(for: room)
+        let nodeA = factory.makeBuildingNode(for: room, wingIndex: 0)
+        let nodeB = factory.makeBuildingNode(for: room, wingIndex: 0)
         XCTAssertEqual(nodeA.childNodes.count, nodeB.childNodes.count)
         for (child1, child2) in zip(nodeA.childNodes, nodeB.childNodes) {
             // Compare geometry types and sizes

--- a/UI/Views/MemoryRoomDetailView.swift
+++ b/UI/Views/MemoryRoomDetailView.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+import QuickLook
+
+/// Displays detailed information for a single memory room including
+/// its attachments. Selecting an attachment presents a Quick Look
+/// preview of the file.
+struct MemoryRoomDetailView: View {
+    let room: MemoryRoom
+    @State private var previewURL: URL?
+    @State private var showPreview = false
+
+    private var attachments: [RoomAttachment] {
+        guard let data = room.attachments,
+              let decoded = try? JSONDecoder().decode([RoomAttachment].self, from: data) else {
+            return []
+        }
+        return decoded
+    }
+
+    var body: some View {
+        List {
+            Section(header: Text("Details")) {
+                Text(room.title)
+                    .font(.headline)
+                if let detail = room.detail, !detail.isEmpty {
+                    Text(detail)
+                }
+                if let date = room.date {
+                    Text(date, style: .date)
+                }
+            }
+            if !attachments.isEmpty {
+                Section(header: Text("Attachments")) {
+                    ForEach(attachments) { attachment in
+                        Button(attachment.fileName) {
+                            openAttachment(attachment)
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle(Text(room.title))
+        .sheet(isPresented: $showPreview) {
+            if let url = previewURL {
+                QuickLookPreview(url: url)
+            }
+        }
+    }
+
+    private func openAttachment(_ attachment: RoomAttachment) {
+        do {
+            var stale = false
+            let url = try URL(resolvingBookmarkData: attachment.fileURLData,
+                              options: [.withoutUI],
+                              relativeTo: nil,
+                              bookmarkDataIsStale: &stale)
+            previewURL = url
+            showPreview = true
+        } catch {
+            print("Failed to resolve URL from bookmark: \(error)")
+        }
+    }
+}
+
+/// Wrapper for `QLPreviewController` so it can be presented from SwiftUI.
+struct QuickLookPreview: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(url: url)
+    }
+
+    func makeUIViewController(context: Context) -> QLPreviewController {
+        let controller = QLPreviewController()
+        controller.dataSource = context.coordinator
+        return controller
+    }
+
+    func updateUIViewController(_ controller: QLPreviewController, context: Context) {}
+
+    class Coordinator: NSObject, QLPreviewControllerDataSource {
+        let url: URL
+
+        init(url: URL) { self.url = url }
+
+        func numberOfPreviewItems(in controller: QLPreviewController) -> Int { 1 }
+
+        func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> QLPreviewItem {
+            url as NSURL
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a fetchRoom(id:) helper to `MemoryRepository`
- colour biomes and add decorative trees in `ProceduralFactory`
- vary terrain height and pass wing index in `CitadelSceneVM`
- implement `MemoryRoomDetailView` with QuickLook preview
- programmatic navigation from the citadel scene
- update procedural factory tests

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688888e188388330b18756519b06048d