### PR TITLE
Implement purge, tap, purchase alerts and attachments

### DIFF
--- a/Domain/Entities/MemoryRoom.swift
+++ b/Domain/Entities/MemoryRoom.swift
@@ -1,6 +1,19 @@
 import CoreData
 import Foundation
 
+/// Represents a single attachment linked to a memory room.
+public struct RoomAttachment: Codable, Identifiable, Hashable {
+    public let id: UUID
+    public let fileURLData: Data // Storing bookmark data for the URL
+    public var fileName: String
+
+    public init(fileURL: URL) throws {
+        self.id = UUID()
+        self.fileName = fileURL.lastPathComponent
+        self.fileURLData = try fileURL.bookmarkData(options: .minimalBookmark, includingResourceValuesForKeys: nil, relativeTo: nil)
+    }
+}
+
 /// Represents a single memory cue within a wing. Each room can
 /// optionally be scheduled by date and hold arbitrary attachments
 /// encoded as a JSON array of file URLs. Rooms can be archived

--- a/Extensions/SceneKit+Helpers.swift
+++ b/Extensions/SceneKit+Helpers.swift
@@ -27,4 +27,12 @@ public extension SCNNode {
         let action = SCNAction.fadeIn(duration: duration)
         runAction(action)
     }
+
+    /// Traverses up the scene graph to find the root node of a building.
+    func findBuildingRoot() -> SCNNode? {
+        if let name = name, name.hasPrefix("Building_") {
+            return self
+        }
+        return parent?.findBuildingRoot()
+    }
 }

--- a/MemoryCitadelApp.swift
+++ b/MemoryCitadelApp.swift
@@ -12,6 +12,7 @@ struct MemoryCitadelApp: App {
   /// `-ui-testing` launch argument is present an in-memory store with
   /// sample data is injected to keep UI tests deterministic.
   private let persistenceController: PersistenceController
+  private let repository = CoreDataMemoryRepository()
 
   /// Creates the application instance. The persistence controller is
   /// selected based on launch arguments so UI tests can run in
@@ -38,6 +39,11 @@ struct MemoryCitadelApp: App {
                 .environment(\.managedObjectContext, persistenceController.container.viewContext)
                 .environmentObject(purchaseManager)
                 .preferredColorScheme(isDarkMode ? .dark : .light)
+                .task {
+                    // Wait 5 seconds after launch to run the purge
+                    try? await Task.sleep(nanoseconds: 5_000_000_000)
+                    try? await repository.purgeArchivedRooms()
+                }
         }
     }
 }

--- a/UI/Views/DocumentPicker.swift
+++ b/UI/Views/DocumentPicker.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+import UIKit
+
+struct DocumentPicker: UIViewControllerRepresentable {
+    var onPick: (URL) -> Void
+
+    func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
+        let picker = UIDocumentPickerViewController(forOpeningContentTypes: [.item], asCopy: true)
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIDocumentPickerViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator: NSObject, UIDocumentPickerDelegate {
+        var parent: DocumentPicker
+
+        init(_ parent: DocumentPicker) {
+            self.parent = parent
+        }
+
+        func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+            guard let url = urls.first else { return }
+            let success = url.startAccessingSecurityScopedResource()
+            defer { url.stopAccessingSecurityScopedResource() }
+
+            if success {
+                parent.onPick(url)
+            }
+        }
+    }
+}

--- a/UI/Views/RootView.swift
+++ b/UI/Views/RootView.swift
@@ -23,7 +23,10 @@ struct RootView: View {
             }
 
             NavigationView {
-                CitadelSceneView(viewModel: CitadelSceneVM(context: context))
+                CitadelSceneView(viewModel: CitadelSceneVM(context: context)) { roomID in
+                    print("Tapped on room with ID: \(roomID)")
+                    // Navigation logic will be added here in the future
+                }
                     .navigationTitle(Text("Citadel"))
             }
             .tabItem {

--- a/UI/Views/SettingsView.swift
+++ b/UI/Views/SettingsView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 struct SettingsView: View {
     @EnvironmentObject private var purchaseManager: PurchaseManager
     @State private var isPurchasing: Bool = false
+    @State private var alertError: CitadelError?
     @AppStorage("isDarkMode") private var isDarkMode: Bool = false
 
     var body: some View {
@@ -26,10 +27,11 @@ struct SettingsView: View {
                             do {
                                 try await purchaseManager.purchasePremium()
                             } catch let error as CitadelError {
-                                // The view itself does not present alerts; instead the root view may
-                                print("Purchase error: \(error)")
+                                // Assign the error to trigger the alert
+                                self.alertError = error
                             } catch {
-                                print("Unknown purchase error: \(error)")
+                                // Wrap the unknown error and assign it
+                                self.alertError = .purchase(error)
                             }
                         }
                     }) {
@@ -48,6 +50,13 @@ struct SettingsView: View {
                     Text("Dark Mode")
                 }
             }
+        }
+        .alert(item: $alertError) { error in
+            Alert(
+                title: Text("Purchase Failed"),
+                message: Text(error.errorDescription ?? "An unknown error occurred."),
+                dismissButton: .default(Text("OK"))
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- add purgeArchivedRooms to repository and call it on launch
- introduce tap gesture in CitadelSceneView and expose callback
- show purchase failure alerts in SettingsView
- create RoomAttachment model and allow attachments in MemoryListView
- add basic DocumentPicker utility

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6888840c29b083308173f272e8cf7671