### PR TITLE
Add animations, paywall, and app icon

### DIFF
--- a/Domain/Services/PurchaseManager.swift
+++ b/Domain/Services/PurchaseManager.swift
@@ -97,6 +97,12 @@ public final class PurchaseManager: ObservableObject {
         }
     }
 
+    /// Restores prior transactions and refreshes entitlement.
+    public func restorePurchases() async {
+        try? await AppStore.sync()
+        await updateEntitlement()
+    }
+
     /// Observes the continuous transaction updates stream. When a
     /// transaction for the premium subscription is revoked or expires
     /// the entitlement is set back to free. This function runs until

--- a/UI/ViewModels/MemoryListVM.swift
+++ b/UI/ViewModels/MemoryListVM.swift
@@ -13,11 +13,14 @@ public final class MemoryListVM: ObservableObject {
 
     private let wing: Wing
     private let repository: MemoryRepository
+    weak var sceneViewModel: CitadelSceneVM?
 
     public init(wing: Wing,
-                repository: MemoryRepository = CoreDataMemoryRepository()) {
+                repository: MemoryRepository = CoreDataMemoryRepository(),
+                sceneViewModel: CitadelSceneVM? = nil) {
         self.wing = wing
         self.repository = repository
+        self.sceneViewModel = sceneViewModel
     }
 
     public func refresh() async {
@@ -56,6 +59,9 @@ public final class MemoryListVM: ObservableObject {
 
     public func deleteRoom(_ room: MemoryRoom) async {
         do {
+            if let sceneViewModel {
+                await sceneViewModel.animateDeletion(for: room)
+            }
             try await repository.deleteRoom(room)
             await refresh()
         } catch let error as CitadelError {

--- a/UI/ViewModels/PalaceListVM.swift
+++ b/UI/ViewModels/PalaceListVM.swift
@@ -10,6 +10,7 @@ import SwiftUI
 public final class PalaceListVM: ObservableObject {
     @Published public private(set) var palaces: [MemoryPalace] = []
     @Published public var alertError: CitadelError?
+    @Published public var shouldShowPaywall: Bool = false
 
     private let repository: MemoryRepository
     private let purchaseManager: PurchaseManager
@@ -38,7 +39,11 @@ public final class PalaceListVM: ObservableObject {
             _ = try await repository.createPalace(name: name)
             await refresh()
         } catch let error as CitadelError {
-            alertError = error
+            if case .procedural = error {
+                shouldShowPaywall = true
+            } else {
+                alertError = error
+            }
         } catch {
             alertError = CitadelError.unknown
         }

--- a/UI/Views/MemoryListView.swift
+++ b/UI/Views/MemoryListView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 struct MemoryListView: View {
     private let wing: Wing
     @ObservedObject private var viewModel: MemoryListVM
+    @EnvironmentObject private var citadelScene: CitadelSceneVM
     @State private var showAddSheet = false
     @State private var title: String = ""
     @State private var detail: String = ""
@@ -23,6 +24,10 @@ struct MemoryListView: View {
 
     var body: some View {
         List {
+            if viewModel.rooms.isEmpty {
+                Text("You have no rooms. Tap the '+' to create one.")
+                    .foregroundColor(.secondary)
+            }
             ForEach(viewModel.rooms) { room in
                 VStack(alignment: .leading, spacing: 4) {
                     Text(room.title)
@@ -79,6 +84,7 @@ struct MemoryListView: View {
             await viewModel.refresh()
         }
         .onAppear {
+            viewModel.sceneViewModel = citadelScene
             Task { await viewModel.refresh() }
         }
         .alert(item: $viewModel.alertError) { error in
@@ -182,6 +188,7 @@ struct MemoryListView_Previews: PreviewProvider {
         wing.palace = palace
         return NavigationView {
             MemoryListView(wing: wing)
+                .environmentObject(CitadelSceneVM())
         }
     }
 }

--- a/UI/Views/PalaceListView.swift
+++ b/UI/Views/PalaceListView.swift
@@ -11,6 +11,10 @@ struct PalaceListView: View {
 
     var body: some View {
         List {
+            if viewModel.palaces.isEmpty {
+                Text("You have no palaces. Tap the '+' to create one.")
+                    .foregroundColor(.secondary)
+            }
             ForEach(viewModel.palaces) { palace in
                 NavigationLink(destination: WingListView(palace: palace)) {
                     VStack(alignment: .leading) {
@@ -72,6 +76,9 @@ struct PalaceListView: View {
                 }
             }
         }
+        .sheet(isPresented: $viewModel.shouldShowPaywall) {
+            PaywallView(isPresented: $viewModel.shouldShowPaywall)
+        }
     }
 }
 
@@ -81,6 +88,7 @@ struct PalaceListView_Previews: PreviewProvider {
             PalaceListView()
                 .environment(\.managedObjectContext, PersistenceController.preview.container.viewContext)
                 .environmentObject(PurchaseManager())
+                .environmentObject(CitadelSceneVM())
         }
     }
 }

--- a/UI/Views/PaywallView.swift
+++ b/UI/Views/PaywallView.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+/// Simple paywall explaining premium benefits and offering a purchase button.
+struct PaywallView: View {
+    @EnvironmentObject private var purchaseManager: PurchaseManager
+    @Binding var isPresented: Bool
+    @State private var isPurchasing = false
+    @State private var alertError: CitadelError?
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 20) {
+                Text("Unlock Premium")
+                    .font(.largeTitle).bold()
+                Text("Create unlimited palaces and access future features. Your memories stay synced via iCloud.")
+                    .multilineTextAlignment(.center)
+                Button(action: {
+                    Task {
+                        isPurchasing = true
+                        defer { isPurchasing = false }
+                        do {
+                            try await purchaseManager.purchasePremium()
+                            isPresented = false
+                        } catch let error as CitadelError {
+                            alertError = error
+                        } catch {
+                            alertError = .purchase(error)
+                        }
+                    }
+                }) {
+                    if isPurchasing {
+                        ProgressView()
+                    } else {
+                        Text("Subscribe")
+                            .font(.headline)
+                    }
+                }
+                Button("Not Now") { isPresented = false }
+            }
+            .padding()
+            .navigationTitle(Text("Premium"))
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { isPresented = false }
+                }
+            }
+        }
+        .alert(item: $alertError) { error in
+            Alert(title: Text(error.errorDescription ?? "Error"))
+        }
+    }
+}
+
+struct PaywallView_Previews: PreviewProvider {
+    static var previews: some View {
+        PaywallView(isPresented: .constant(true))
+            .environmentObject(PurchaseManager())
+    }
+}

--- a/UI/Views/RootView.swift
+++ b/UI/Views/RootView.swift
@@ -11,6 +11,9 @@ struct RootView: View {
     @EnvironmentObject private var purchaseManager: PurchaseManager
     @Environment(\.managedObjectContext) private var context
 
+    /// Shared scene view model so other views can trigger animations.
+    @StateObject private var citadelViewModel = CitadelSceneVM()
+
     @State private var selectedTab: Int = 0
     @State private var navigationPath = NavigationPath()
 
@@ -33,7 +36,7 @@ struct RootView: View {
             .tag(0)
             
             NavigationView {
-                CitadelSceneView(viewModel: CitadelSceneVM(context: context)) { roomID in
+                CitadelSceneView(viewModel: citadelViewModel) { roomID in
                     Task {
                         let repository = CoreDataMemoryRepository()
                         if let room = try? await repository.fetchRoom(by: roomID) {
@@ -43,7 +46,7 @@ struct RootView: View {
                         }
                     }
                 }
-                    .navigationTitle(Text("Citadel"))
+                .navigationTitle(Text("Citadel"))
             }
             .tabItem {
                 Image(systemName: "cube")
@@ -61,6 +64,7 @@ struct RootView: View {
             }
             .tag(2)
         }
+        .environmentObject(citadelViewModel)
     }
 }
 
@@ -69,5 +73,6 @@ struct RootView_Previews: PreviewProvider {
         RootView()
             .environment(\.managedObjectContext, PersistenceController.preview.container.viewContext)
             .environmentObject(PurchaseManager())
+            .environmentObject(CitadelSceneVM())
     }
 }

--- a/UI/Views/SettingsView.swift
+++ b/UI/Views/SettingsView.swift
@@ -42,6 +42,9 @@ struct SettingsView: View {
                             Text("Unlock Premium")
                         }
                     }
+                    Button("Restore Purchases") {
+                        Task { await purchaseManager.restorePurchases() }
+                    }
                 }
             }
 

--- a/UI/Views/WingListView.swift
+++ b/UI/Views/WingListView.swift
@@ -15,6 +15,10 @@ struct WingListView: View {
 
     var body: some View {
         List {
+            if viewModel.wings.isEmpty {
+                Text("You have no wings. Tap the '+' to create one.")
+                    .foregroundColor(.secondary)
+            }
             ForEach(viewModel.wings) { wing in
                 NavigationLink(destination: MemoryListView(wing: wing)) {
                     Text(wing.title)
@@ -81,6 +85,7 @@ struct WingListView_Previews: PreviewProvider {
         palace.name = "Sample Palace"
         return NavigationView {
             WingListView(palace: palace)
+                .environmentObject(CitadelSceneVM())
         }
     }
 }


### PR DESCRIPTION
## Summary
- share `CitadelSceneVM` instance across app
- animate building fade-in and deletion with impulse
- add empty states for all lists
- show dedicated paywall sheet when exceeding palace limit
- support restoring purchases
- add placeholder app icon set
- **remove all app icon PNGs** as requested

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6888b52687f883308cf20232b22099ad