### PR TITLE
Add error handling, editing, and haptics

### DIFF
--- a/Domain/Services/HapticManager.swift
+++ b/Domain/Services/HapticManager.swift
@@ -1,0 +1,18 @@
+import UIKit
+
+/// Provides simple access to haptic feedback throughout the app.
+public enum HapticManager {
+    /// Triggers an impact feedback.
+    public static func impact(_ style: UIImpactFeedbackGenerator.FeedbackStyle) {
+        let generator = UIImpactFeedbackGenerator(style: style)
+        generator.prepare()
+        generator.impactOccurred()
+    }
+
+    /// Triggers a notification feedback.
+    public static func notification(_ type: UINotificationFeedbackGenerator.FeedbackType) {
+        let generator = UINotificationFeedbackGenerator()
+        generator.prepare()
+        generator.notificationOccurred(type)
+    }
+}

--- a/Domain/Services/MemoryRepository.swift
+++ b/Domain/Services/MemoryRepository.swift
@@ -15,6 +15,7 @@ public protocol MemoryRepository {
     func deleteWing(_ wing: Wing) async throws
 
     func createRoom(in wing: Wing, title: String, detail: String?, date: Date?, attachments: Data?) async throws -> MemoryRoom
+    func updateRoom(_ room: MemoryRoom, title: String, detail: String?) async throws
     func archiveRoom(_ room: MemoryRoom) async throws
     func deleteRoom(_ room: MemoryRoom) async throws
     func purgeArchivedRooms() async throws
@@ -126,6 +127,17 @@ public final class CoreDataMemoryRepository: MemoryRepository {
         do {
             try persistenceController.saveContext()
             return room
+        } catch {
+            throw error
+        }
+    }
+
+    public func updateRoom(_ room: MemoryRoom, title: String, detail: String?) async throws {
+        room.title = title
+        room.detail = detail
+        room.updatedAt = Date()
+        do {
+            try persistenceController.saveContext()
         } catch {
             throw error
         }

--- a/Domain/Services/PurchaseManager.swift
+++ b/Domain/Services/PurchaseManager.swift
@@ -98,9 +98,13 @@ public final class PurchaseManager: ObservableObject {
     }
 
     /// Restores prior transactions and refreshes entitlement.
-    public func restorePurchases() async {
-        try? await AppStore.sync()
-        await updateEntitlement()
+    public func restorePurchases() async throws {
+        do {
+            try await AppStore.sync()
+            await updateEntitlement()
+        } catch {
+            throw CitadelError.purchase(error)
+        }
     }
 
     /// Observes the continuous transaction updates stream. When a

--- a/UI/Views/CitadelSceneView.swift
+++ b/UI/Views/CitadelSceneView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import SceneKit
+import UIKit
 
 /// Wraps an `SCNView` for use within SwiftUI. Displays a 3D scene
 /// managed by `CitadelSceneVM` and bridges pinch and pan gestures to
@@ -103,6 +104,7 @@ struct CitadelSceneView: UIViewRepresentable {
 
             let uuidString = String(name.dropFirst(prefix.count))
             if let uuid = UUID(uuidString: uuidString) {
+                HapticManager.impact(.light)
                 // Call the closure with the found UUID
                 onRoomTapped?(uuid)
             }

--- a/UI/Views/MemoryListView.swift
+++ b/UI/Views/MemoryListView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 /// Lists the memory rooms within a given wing. Rooms can be
 /// searched, added, archived and deleted. When a room is archived it
@@ -145,6 +146,7 @@ struct MemoryListView: View {
                             let attachmentsData = try? JSONEncoder().encode(attachments)
                             Task {
                                 await viewModel.addRoom(title: trimmedTitle, detail: detail.isEmpty ? nil : detail, date: optionalDate, attachments: attachmentsData)
+                                HapticManager.notification(.success)
                                 clearInputs()
                                 showAddSheet = false
                             }

--- a/UI/Views/PalaceListView.swift
+++ b/UI/Views/PalaceListView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 /// Displays a list of memory palaces. Users can create, select or
 /// delete palaces. When the free tier limit is reached tapping the
@@ -65,6 +66,7 @@ struct PalaceListView: View {
                         Button("Add") {
                             let trimmed = newPalaceName.trimmingCharacters(in: .whitespacesAndNewlines)
                             guard !trimmed.isEmpty else { return }
+                            HapticManager.impact(.medium)
                             Task {
                                 await viewModel.addPalace(name: trimmed)
                                 newPalaceName = ""

--- a/UI/Views/PaywallView.swift
+++ b/UI/Views/PaywallView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 /// Simple paywall explaining premium benefits and offering a purchase button.
 struct PaywallView: View {
@@ -15,6 +16,7 @@ struct PaywallView: View {
                 Text("Create unlimited palaces and access future features. Your memories stay synced via iCloud.")
                     .multilineTextAlignment(.center)
                 Button(action: {
+                    HapticManager.impact(.medium)
                     Task {
                         isPurchasing = true
                         defer { isPurchasing = false }

--- a/UI/Views/SettingsView.swift
+++ b/UI/Views/SettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 /// Presents application settings including subscription status and
 /// theme selection. Users can upgrade to the premium tier via a
@@ -21,6 +22,7 @@ struct SettingsView: View {
                 }
                 if purchaseManager.entitlement == .free {
                     Button(action: {
+                        HapticManager.impact(.medium)
                         Task {
                             isPurchasing = true
                             defer { isPurchasing = false }
@@ -43,7 +45,13 @@ struct SettingsView: View {
                         }
                     }
                     Button("Restore Purchases") {
-                        Task { await purchaseManager.restorePurchases() }
+                        Task {
+                            do {
+                                try await purchaseManager.restorePurchases()
+                            } catch {
+                                self.alertError = .purchase(error)
+                            }
+                        }
                     }
                 }
             }

--- a/UI/Views/WingListView.swift
+++ b/UI/Views/WingListView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 /// Displays the wings within a specific palace. Users can add new
 /// wings and navigate to the list of rooms in each wing.
@@ -64,6 +65,7 @@ struct WingListView: View {
                         Button("Add") {
                             let trimmed = newWingTitle.trimmingCharacters(in: .whitespacesAndNewlines)
                             guard !trimmed.isEmpty else { return }
+                            HapticManager.impact(.medium)
                             Task {
                                 await viewModel.addWing(title: trimmed)
                                 newWingTitle = ""


### PR DESCRIPTION
## Summary
- improve restorePurchases error propagation
- update SettingsView to handle restore errors
- allow editing MemoryRoom title and detail
- add repository update function
- provide simple HapticManager
- trigger haptics on various user actions

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6888c68a4a2c833088e194b91ed791e5